### PR TITLE
Updating the fabsim import to match FabSim3's current import scheme

### DIFF
--- a/FabProfile.py
+++ b/FabProfile.py
@@ -8,7 +8,11 @@
 #from base import ClassTimeIt
 import time
 import os
-from base.fab import *
+try:
+    from fabsim.base.fab import *
+except ImportError:
+    from base.fab import *
+
 # Add local script, blackbox and template path.
 add_local_paths("FabProfile")
 


### PR DESCRIPTION
When installing the plugin to the current FabSim3 project, each subsequent call to `fabsim` results in the following error:

```bash
No module named 'base'
Traceback (most recent call last):
  File "/home/jo/repos/fabsim-plugins/fabsim/deploy/machines.py", line 250, in load_plugins
    plugin = importlib.import_module("plugins.{}.{}".format(key, key))
  File "/home/jo/.pyenv/versions/3.10.12/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/home/jo/repos/fabsim-plugins/plugins/FabProfile/FabProfile.py", line 11, in <module>
    from base.fab import *
ModuleNotFoundError: No module named 'base'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/jo/repos/fabsim-plugins/fabsim/bin/fabsim", line 46, in <module>
    sys.exit(fabsim_main.main())
  File "/home/jo/repos/fabsim-plugins/fabsim/base/fabsim_main.py", line 74, in main
    load_plugins()
  File "/home/jo/repos/fabsim-plugins/fabsim/deploy/machines.py", line 267, in load_plugins
    raise ImportError(e)
ImportError: No module named 'base'
```

The solution is as easy as replacing the FabSim import statement in `FabProfile.py` by an updated try-except statement.